### PR TITLE
feat: add custom service for registering MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0-beta.2] (2025-10-04)
+
+### ✨ Features
+
+- add custom service for registering MCP tools ([ad45e91](../../commit/ad45e9137f6eacc74caa6306e699dbec8a5a221a))
+
+### 🧹 Chore
+
+- add prepare-release and changelog scripts to package.json ([7451d8f](../../commit/7451d8f67166e3f353a937d45d75d59e089dac1a))
+
+## [Unknown] (2025-09-17)
+
+### ✨ Features
+
+- admin ui removed ([a8376bb](../../commit/a8376bba64c419115cd4c7bca128774ef98a3a41))
+- implement structured logging and enhance tool registration ([4fe9c73](../../commit/4fe9c738b842983a2d587d61368e1662ae383ab7))
+- enhance transport management and configuration ([dea37ee](../../commit/dea37ee69badbb561255eacf7545f9c1dc2aecc4))
+- project reorganised ([c84baa7](../../commit/c84baa708fb88ddf2026e6d6cb41b2315a131612))
+
+### 🧹 Chore
+
+- update dependencies and improve TypeScript testing ([471792a](../../commit/471792a43c85fb3d002e7fe6301eac96f630b8d5))
+- remove packageManager ([ca08358](../../commit/ca08358d89524eeae8adf62ed7ed41ef77a29ad8))
+- bump node image version ([f338499](../../commit/f338499ea7873dbe3c67e625824ea549a02d2dfc))
+- circle ci config ([ca2c755](../../commit/ca2c755c5436c23105b54ac64f4356d16e139150))
+
+### 📦 Other Changes
+
+- Add .circleci/config.yml ([2b0aac2](../../commit/2b0aac27211d6fa44842f825bcba16b69be3464e))
+- Add MIT License file to the project for legal protection and usage guidelines. ([37e5c0e](../../commit/37e5c0e71d1a8461f1ab89fd635f8abcb019b8f9))
+- Add MCP integration guidelines and TypeScript conventions; create configuration and development structure for Strapi plugin ([3d8cba9](../../commit/3d8cba9637e82416eb2520da28043b8ec9cf502f))
+- Update package.json and pnpm-lock.yaml for dependency management; add new Strapi types and event controller for handling streamable HTTP requests. ([7ff3137](../../commit/7ff3137a077f245d9d470befb83255f92c24310f))
+- init 2 ([e119598](../../commit/e119598820a8e800e88070ea0a7528ed4ec1a6fb))
+- init ([99f943c](../../commit/99f943cce262e194b09cbc7fe16ae9411e76b1d4))
+

--- a/README.md
+++ b/README.md
@@ -290,6 +290,34 @@ The plugin exposes several categories of tools:
 
 All tools follow MCP protocol standards and provide comprehensive error handling and validation.
 
+### Custom Tools
+
+The plugin supports registering custom MCP tools through the custom service. This allows developers to extend the plugin's functionality by adding domain-specific tools that integrate with their Strapi application. Custom tools are registered using the `registerTool` method and become available to MCP clients alongside the built-in tools.
+
+The `registerTool` method accepts a `McpToolDefinition` object with the following TypeScript interface: `name` (string) for the tool identifier, `callback` (ToolCallback) for the execution function that returns MCP-formatted content, optional `argsSchema` (ZodRawShape) for argument validation, optional `description` (string) for tool documentation, and optional `annotations` (ToolAnnotations) for additional metadata. The callback function receives validated arguments and must return content in MCP format with a `content` array containing text, image, or other supported content types.
+
+```ts
+
+const mpcCustomService = strapi.plugin("mcp").service("custom");
+
+mpcCustomService.registerTool({
+  name: "custom-mango",
+  description: "Mango tool",
+  argsSchema: {},
+  callback: async () => ({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          success: true,
+          message: "Mango tool",
+        }),
+      },
+    ],
+  }),
+});
+```
+
 ## Usage Examples
 
 Once your MCP client is connected, you can interact with your Strapi instance using natural language. Here are comprehensive examples of how to use the plugin's capabilities:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta.1",
+  "version": "1.1.0-beta.2",
   "keywords": [],
   "type": "commonjs",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.1",
   "keywords": [],
   "type": "commonjs",
   "exports": {

--- a/server/src/controllers/events.controller.ts
+++ b/server/src/controllers/events.controller.ts
@@ -47,6 +47,7 @@ const eventsController = ({ strapi }: StrapiContext) => {
   const contentTypesService = plugin.service('contentTypes');
   const strapiInfoService = plugin.service('strapiInfo');
   const servicesService = plugin.service('services');
+  const customService = plugin.service('custom');
 
   const pluginConfig = getPluginConfig(strapi);
   const transportStore = createTransportStore({
@@ -68,6 +69,7 @@ const eventsController = ({ strapi }: StrapiContext) => {
     contentTypesService.addTools(server);
     strapiInfoService.addTools(server);
     servicesService.addTools(server);
+    customService.addTools(server);
 
     return server;
   };

--- a/server/src/services/custom/custom.service.spec.ts
+++ b/server/src/services/custom/custom.service.spec.ts
@@ -1,0 +1,303 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { faker } from '@faker-js/faker';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+import { McpToolDefinition } from '../../common';
+import customService from './custom.service';
+
+describe('customService', () => {
+  let service: ReturnType<typeof customService>;
+  let mockServer: McpServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = customService();
+    mockServer = {
+      tool: vi.fn(),
+    } as unknown as McpServer;
+  });
+
+  describe('registerTool', () => {
+    it('allows registering a tool with minimal definition', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const toolDefinition: McpToolDefinition<{}> = {
+        name: toolName,
+        callback: vi.fn(),
+      };
+
+      // When & Then
+      expect(() => service.registerTool(toolDefinition)).not.toThrow();
+    });
+
+    it('allows registering a tool with full definition', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const description = faker.lorem.sentence();
+      const toolDefinition: McpToolDefinition<{ input: z.ZodString }> = {
+        name: toolName,
+        description,
+        argsSchema: {
+          input: z.string(),
+        },
+        callback: vi.fn(),
+        annotations: {
+          audience: ['user'],
+        },
+      };
+
+      // When & Then
+      expect(() => service.registerTool(toolDefinition)).not.toThrow();
+    });
+
+    it('allows registering multiple tools', () => {
+      // Given
+      const tool1: McpToolDefinition<{}> = {
+        name: faker.word.noun(),
+        callback: vi.fn(),
+      };
+      const tool2: McpToolDefinition<{ value: z.ZodNumber }> = {
+        name: faker.word.noun(),
+        description: faker.lorem.sentence(),
+        argsSchema: { value: z.number() },
+        callback: vi.fn(),
+      };
+
+      // When & Then
+      expect(() => {
+        service.registerTool(tool1);
+        service.registerTool(tool2);
+      }).not.toThrow();
+    });
+  });
+
+  describe('addTools', () => {
+    it('registers no tools when none have been registered', () => {
+      // Given
+      // No tools registered
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).not.toHaveBeenCalled();
+    });
+
+    it('registers a single tool with minimal definition', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<{}> = {
+        name: toolName,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, callback);
+    });
+
+    it('registers a tool with description and args schema', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const description = faker.lorem.sentence();
+      const argsSchema = { input: z.string() };
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<typeof argsSchema> = {
+        name: toolName,
+        description,
+        argsSchema,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, description, argsSchema, callback);
+    });
+
+    it('registers a tool with args schema and annotations', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const argsSchema = { count: z.number() };
+      const annotations = { audience: ['user'] as const };
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<typeof argsSchema> = {
+        name: toolName,
+        argsSchema,
+        annotations,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, argsSchema, annotations, callback);
+    });
+
+    it('registers a tool with all optional parameters', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const description = faker.lorem.sentence();
+      const argsSchema = { data: z.object({ id: z.string() }) };
+      const annotations = { audience: ['user'] as const };
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<typeof argsSchema> = {
+        name: toolName,
+        description,
+        argsSchema,
+        annotations,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, description, argsSchema, annotations, callback);
+    });
+
+    it('registers multiple tools in order', () => {
+      // Given
+      const tool1Name = faker.word.noun();
+      const tool2Name = faker.word.noun();
+      const tool3Name = faker.word.noun();
+      
+      const tool1: McpToolDefinition<{}> = {
+        name: tool1Name,
+        callback: vi.fn(),
+      };
+      const tool2: McpToolDefinition<{ input: z.ZodString }> = {
+        name: tool2Name,
+        description: faker.lorem.sentence(),
+        argsSchema: { input: z.string() },
+        callback: vi.fn(),
+      };
+      const tool3: McpToolDefinition<{ value: z.ZodNumber }> = {
+        name: tool3Name,
+        argsSchema: { value: z.number() },
+        callback: vi.fn(),
+      };
+
+      service.registerTool(tool1);
+      service.registerTool(tool2);
+      service.registerTool(tool3);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(3);
+      expect(mockServer.tool).toHaveBeenNthCalledWith(1, tool1Name, tool1.callback);
+      expect(mockServer.tool).toHaveBeenNthCalledWith(2, tool2Name, tool2.description, tool2.argsSchema, tool2.callback);
+      expect(mockServer.tool).toHaveBeenNthCalledWith(3, tool3Name, tool3.argsSchema, tool3.callback);
+    });
+
+    it('can be called multiple times without duplicate registrations', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const toolDefinition: McpToolDefinition<{}> = {
+        name: toolName,
+        callback: vi.fn(),
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(2);
+      expect(mockServer.tool).toHaveBeenNthCalledWith(1, toolName, toolDefinition.callback);
+      expect(mockServer.tool).toHaveBeenNthCalledWith(2, toolName, toolDefinition.callback);
+    });
+  });
+
+  describe('service isolation', () => {
+    it('creates independent service instances', () => {
+      // Given
+      const service1 = customService();
+      const service2 = customService();
+      const tool1: McpToolDefinition<{}> = {
+        name: faker.word.noun(),
+        callback: vi.fn(),
+      };
+      const tool2: McpToolDefinition<{}> = {
+        name: faker.word.noun(),
+        callback: vi.fn(),
+      };
+
+      // When
+      service1.registerTool(tool1);
+      service2.registerTool(tool2);
+
+      service1.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(tool1.name, tool1.callback);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles tools with only args schema', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const argsSchema = { query: z.string() };
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<typeof argsSchema> = {
+        name: toolName,
+        argsSchema,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, argsSchema, callback);
+    });
+
+    it('handles tools with complex Zod schemas', () => {
+      // Given
+      const toolName = faker.word.noun();
+      const argsSchema = {
+        user: z.object({
+          id: z.string(),
+          email: z.string().email(),
+          age: z.number().optional(),
+        }),
+        filters: z.array(z.string()).optional(),
+      };
+      const callback = vi.fn();
+      const toolDefinition: McpToolDefinition<typeof argsSchema> = {
+        name: toolName,
+        argsSchema,
+        callback,
+      };
+      service.registerTool(toolDefinition);
+
+      // When
+      service.addTools(mockServer);
+
+      // Then
+      expect(mockServer.tool).toHaveBeenCalledTimes(1);
+      expect(mockServer.tool).toHaveBeenCalledWith(toolName, argsSchema, callback);
+    });
+  });
+});

--- a/server/src/services/custom/custom.service.ts
+++ b/server/src/services/custom/custom.service.ts
@@ -1,0 +1,112 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { ZodRawShape } from 'zod';
+
+import { McpToolDefinition, registerTool } from '../../common';
+
+/**
+ * Custom service factory for managing user-defined MCP tools.
+ * 
+ * This service provides a registry system that allows developers to register custom
+ * MCP (Model Context Protocol) tools dynamically. Tools are stored in memory until
+ * they are registered with an MCP server instance.
+ * 
+ * The service follows a two-phase approach:
+ * 1. **Registration Phase**: Tools are registered via `registerTool()` and stored in memory
+ * 2. **Application Phase**: All registered tools are applied to an MCP server via `addTools()`
+ * 
+ * This pattern allows for flexible tool composition and ensures all custom tools
+ * are properly registered with the MCP server when the plugin initializes.
+ * 
+ * @returns An object with methods for registering and applying custom tools
+ * 
+ * @example
+ * ```typescript
+ * import customService from './custom.service';
+ * 
+ * const service = customService();
+ * 
+ * // Register a custom tool
+ * service.registerTool({
+ *   name: 'my-custom-tool',
+ *   description: 'Does something custom',
+ *   argsSchema: { input: z.string() },
+ *   callback: async (args) => ({
+ *     content: [{ type: 'text', text: `Processed: ${args.input}` }]
+ *   })
+ * });
+ * 
+ * // Later, register all tools with the MCP server
+ * service.addTools(mcpServer);
+ * ```
+ */
+export default () => {
+  /** Registry to store custom tool definitions before they are registered with the MCP server */
+  const tools: Array<McpToolDefinition<ZodRawShape>> = [];
+
+  return {
+  /**
+   * Registers a custom MCP tool definition for later application to a server.
+   * 
+   * This method adds a tool definition to the internal registry. The tool will not
+   * be active until `addTools()` is called with an MCP server instance.
+   * 
+   * @template Args - The Zod schema shape for validating tool arguments
+   * @param definition - The complete tool definition including name, callback, and optional schema/description
+   * 
+   * @example
+   * ```typescript
+   * service.registerTool({
+   *   name: 'calculate-sum',
+   *   description: 'Adds two numbers together',
+   *   argsSchema: {
+   *     a: z.number(),
+   *     b: z.number()
+   *   },
+   *   callback: async ({ a, b }) => ({
+   *     content: [{ type: 'text', text: `${a} + ${b} = ${a + b}` }]
+   *   })
+   * });
+   * ```
+   */
+  registerTool: <Args extends ZodRawShape>(definition: McpToolDefinition<Args>) => {
+    tools.push(definition);
+  },
+
+  /**
+   * Registers all previously registered custom tools with an MCP server.
+   * 
+   * This method iterates through all tools in the registry and registers them
+   * with the provided MCP server instance. After this call, all custom tools
+   * will be available for use by MCP clients.
+   * 
+   * @param server - The MCP server instance to register tools with
+   * 
+   * @example
+   * ```typescript
+   * import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+   * 
+   * const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+   * const service = customService();
+   * 
+   * // Register some custom tools first
+   * service.registerTool(myCustomTool);
+   * service.registerTool(anotherCustomTool);
+   * 
+   * // Apply all registered tools to the server
+   * service.addTools(server);
+   * ```
+   */
+  addTools: (server: McpServer) => {
+    if (tools.length === 0) {
+      return;
+    }
+
+    tools.forEach((tool) => {
+      registerTool({
+        server,
+        tool,
+      });
+    });
+  },
+  };
+};

--- a/server/src/services/custom/index.ts
+++ b/server/src/services/custom/index.ts
@@ -1,0 +1,1 @@
+export { default } from './custom.service';

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -1,11 +1,13 @@
 import contentTypesService from './content-types';
 import strapiInfoService from './strapi-info';
 import servicesService from './services';
+import customService from './custom';
 
 const services = {
   contentTypes: contentTypesService,
   strapiInfo: strapiInfoService,
   services: servicesService,
+  custom: customService,
 };
 
 export type Services = {


### PR DESCRIPTION
- Introduced a new custom service that allows developers to register and manage custom MCP tools dynamically.
- Updated README to include documentation on how to use the new custom tools feature.
- Modified events and services controllers to integrate the custom service.
- Added unit tests for the custom service to ensure proper functionality and tool registration.